### PR TITLE
Remove default browser check and python dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,13 +3,15 @@
   "version": "1.0.0",
   "description": "A few scripts to get started",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "httpster -p 8080"
   },
   "author": "",
   "license": "Apache-2.0",
   "repository": "https://github.com/paulirish/automated-chrome-profiling",
   "dependencies": {
     "devtools-timeline-model": "^1.0",
-    "chrome-remote-interface": "^0.11.0"
+    "chrome-remote-interface": "^0.11.0",
+    "httpster": "^1.0.3"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -5,22 +5,22 @@ We can use the [Chrome debugging protocol](https://developer.chrome.com/devtools
 
 **Step 1: Clone this repo and serve it**
 
-```sh 
+```sh
 git clone https://github.com/paulirish/automated-chrome-profiling
 cd automated-chrome-profiling
-python -m SimpleHTTPServer 8080  # app is hardcoded to 8080
+npm start  # serves the folder at http://localhost:8080/ (port hardcoded)
 ```
 
 **Step 2: Run Chrome with an open debugging port:**
 
 ```sh
 # linux
-google-chrome --remote-debugging-port=9222 --user-data-dir="$TMPDIR/chrome-profiling"
+google-chrome --remote-debugging-port=9222 --user-data-dir=$TMPDIR/chrome-profiling --no-default-browser-check
 
 # mac
-/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome --remote-debugging-port=9222 --user-data-dir="$TMPDIR/chrome-profiling"
+/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome --remote-debugging-port=9222 --user-data-dir=$TMPDIR/chrome-profiling --no-default-browser-check
 ```
-Navigate off the start page to example.com or something. 
+Navigate off the start page to example.com or something.
 
 **Step 3: Run the CPU profiling demo app**
 


### PR DESCRIPTION
- Switched from `SimpleHTTPServer` to [`httpster`](https://simbco.github.io/httpster/) to keep it all in node
- Removed the double quotes around the tmp dir that caused it to not correctly use the `$TMPDIR` variable.
- Added the `--no-default-browser-check` option to avoid the browser check popup on start
