### PR TITLE
Adding 2 trace categories to get the full JS stacks

### DIFF
--- a/get-timeline-trace.js
+++ b/get-timeline-trace.js
@@ -2,7 +2,7 @@ var fs = require('fs');
 var Chrome = require('chrome-remote-interface');
 var summary = require('./util/browser-perf-summary')
 
-var TRACE_CATEGORIES = ["-*", "devtools.timeline", "disabled-by-default-devtools.timeline", "disabled-by-default-devtools.timeline.frame", "toplevel", "blink.console", "disabled-by-default-devtools.timeline.stack", "disabled-by-default-devtools.screenshot", "disabled-by-default-v8.cpu_profile"];
+var TRACE_CATEGORIES = ["-*", "devtools.timeline", "disabled-by-default-devtools.timeline", "disabled-by-default-devtools.timeline.frame", "toplevel", "blink.console", "disabled-by-default-devtools.timeline.stack", "disabled-by-default-devtools.screenshot", "disabled-by-default-v8.cpu_profile", "disabled-by-default-v8.cpu_profiler", "disabled-by-default-v8.cpu_profiler.hires"];
 
 var rawEvents = [];
 
@@ -42,5 +42,3 @@ Chrome(function (chrome) {
 }).on('error', function (e) {
     console.error('Cannot connect to Chrome', e);
 });
-
-


### PR DESCRIPTION
(so we are getting the same timeline as if you hit the "record" button
on the timeline/performance tab)

see https://github.com/paulirish/automated-chrome-profiling/issues/10
for context